### PR TITLE
Potential fix for code scanning alert no. 16: Client-side cross-site scripting

### DIFF
--- a/app/src/static/js/downloads.js
+++ b/app/src/static/js/downloads.js
@@ -248,7 +248,7 @@
             <div class="download-meta">
               ${sizeStr ? `<span>${sizeStr}</span>` : ''}
               ${recStr ? `<span>${recStr}</span>` : ''}
-              ${etaStr ? `<span>${etaStr}</span>` : ''}
+              ${etaStr ? `<span>${escapeHtml(etaStr)}</span>` : ''}
               ${safeFileName ? `<span>${safeFileName}</span>` : ''}
             </div>
             <div class="download-actions">


### PR DESCRIPTION
Potential fix for [https://github.com/mteij/Zentrio/security/code-scanning/16](https://github.com/mteij/Zentrio/security/code-scanning/16)

To fix the problem, all variables interpolated into HTML or inserted via `.innerHTML` should be contextually escaped or sanitized, even if they are purported to be of numeric type, as a defense-in-depth measure. The immediate fix is to escape the `etaStr` value before inserting it into the HTML. Although `etaStr` is only set if `item.eta` is a number, we should sanitize all variables as a best practice and for future maintainability.

Specifically, in app/src/static/js/downloads.js:
- On line 251, change `${etaStr}` to `escapeHtml(etaStr)` (but only if `etaStr` is non-empty).
- Since `escapeHtml()` is already defined and used elsewhere, no new dependency is needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
