### PR TITLE
Potential fix for code scanning alert no. 21: Client-side URL redirect

### DIFF
--- a/app/src/static/js/downloads.js
+++ b/app/src/static/js/downloads.js
@@ -369,6 +369,8 @@
 
   // message events from downloadsManager script inside session iframe or same context
   window.addEventListener('message', (e) => {
+    // Only accept messages from same origin
+    if (e.origin !== window.location.origin) return;
     const data = e.data;
     if (!data || typeof data !== 'object' || !data.type) return;
 


### PR DESCRIPTION
Potential fix for [https://github.com/mteij/Zentrio/security/code-scanning/21](https://github.com/mteij/Zentrio/security/code-scanning/21)

To address untrusted URL redirection, we must:  
- Ensure that the only URLs stored and opened in the queue (specifically as `blobUrl`) come from trusted, same-origin sources or represent only object URLs created in this window/session context.
- Add origin checking to the `window.addEventListener('message', ...)` handler, so only messages from allowed (same-origin) sources are processed.
- Implement or strengthen the logic for `isSafeSameOriginUrl` (if you control it), but given the snippet, we don't see its definition—so we will act on input sanitization for messages.
- On line 371, before using any data from messages, check that `e.origin === window.location.origin`.  
This prevents untrusted, cross-origin scripts from injecting malicious URLs.

**Edits to make:**  
- In `app/src/static/js/downloads.js`, inside the `window.addEventListener('message', ...)` handler, add a conditional to check the message's origin matches `window.location.origin`.  
- If the origin does not match, return early.
- This check must appear as the first statement in the handler, before any use of `e.data`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
